### PR TITLE
Fix: Run pull_request workflow on pull_request_target

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,5 +1,5 @@
 on:
-  pull_request:
+  pull_request_target:
 
 name: Pull Request Checks
 


### PR DESCRIPTION
According to the GitHub docs:

    https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target

we get access to GITHUB_TOKEN with this, which is what we need to post
comments to the PR.
