### PR TITLE
Add println to test labeler action

### DIFF
--- a/example-bin/src/main.rs
+++ b/example-bin/src/main.rs
@@ -1,3 +1,4 @@
 fn main() {
     println!("Hello, world!");
+    println!("I am an example binary");
 }


### PR DESCRIPTION
This should now automatically be labeled with the `example-bin` label.