### PR TITLE
Replace actions-rs/toolchain with dtolnay

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,9 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          override: true
       - uses: swatinem/rust-cache@v2
       - name: cargo-check
         uses: actions-rs/cargo@v1
@@ -63,7 +62,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: 1.60.0
       - run: rustup component add rustfmt
@@ -105,10 +105,9 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v3
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: ${{ matrix.rust }}
-          override: true
       - uses: swatinem/rust-cache@v2
       - name: cargo-test
         uses: actions-rs/cargo@v1
@@ -123,10 +122,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: 1.60.0
-          override: true
       - uses: swatinem/rust-cache@v2
       - run: rustup component add clippy
       - name: cargo-clippy
@@ -164,10 +163,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: 1.60.0
-          override: true
       - uses: swatinem/rust-cache@v2
       - run: cargo install --locked cargo-outdated
       - name: cargo-outdated
@@ -189,11 +188,11 @@ jobs:
           - x86_64-unknown-freebsd
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: 1.60.0
-          target: ${{ matrix.target }}
-          override: true
+          targets: ${{ matrix.target }}
       - uses: swatinem/rust-cache@v2
       - uses: actions-rs/cargo@v1
         with:
@@ -212,11 +211,11 @@ jobs:
           - armv7-unknown-linux-gnueabihf
     steps:
       - uses: actions/checkout@v3
-      - uses: actions-rs/toolchain@v1
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: 1.60.0
-          target: ${{ matrix.target }}
-          override: true
+          targets: ${{ matrix.target }}
       - uses: swatinem/rust-cache@v2
       - uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -78,10 +78,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - uses: actions-rs/toolchain@v1
+      - name: Install toolchain
+        uses: dtolnay/rust-toolchain@master
         with:
           toolchain: nightly
-          override: true
       - uses: swatinem/rust-cache@v2
       - run: cargo install --locked cargo-public-api
       - run: echo -e "### API changes\n\n" >> apidiff.txt


### PR DESCRIPTION
actions-rs/toolchain is unmaintained. The proposed alternative is from dtolnay, which is used widely, so we should use that instead.